### PR TITLE
package.json: Fix opentype@^1.3..4 module name

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "file-saver": "^2.0.5",
     "ionicons": "^7.0.0",
     "makerjs": "^0.18.0",
-    "opentype": "^1.3.4",
+    "opentype.js": "^1.3.4",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.13.0"


### PR DESCRIPTION
For some reason this project depends on opentyp@^1.3.4 module, so running a `npm install` it fails with the following error:

   notarget No matching version found for opentype@^1.3.4

opentype module doesn't exist, in fact there seems to be a typo here, as the correct name is opentype.js. So replace the module dependency to the appropiate name.